### PR TITLE
can add one photo to adventures now and fixed photo upload bug for review+adventure

### DIFF
--- a/app/controllers/adventures_controller.rb
+++ b/app/controllers/adventures_controller.rb
@@ -80,6 +80,6 @@ class AdventuresController < ApplicationController
   end
 
   def adventure_params
-    params.require(:adventure).permit(:title, :description, :category, :distance, :stroller_friendly, :youngest_age, :difficulty, :parking, :public_transport, :directions, :address, photos: [])
+    params.require(:adventure).permit(:title, :description, :category, :distance, :avg_duration, :stroller_friendly, :youngest_age, :difficulty, :parking, :public_transport, :directions, :address, :photo)
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -39,7 +39,7 @@ class ReviewsController < ApplicationController
   private
 
   def review_params
-    params.require(:review).permit(:tagline, :content, :rating, :user_id, :adventure_id)
+    params.require(:review).permit(:tagline, :content, :rating, :user_id, :adventure_id, :duration, :youngest_age, photos: [])
   end
 
   def set_review

--- a/app/models/adventure.rb
+++ b/app/models/adventure.rb
@@ -1,6 +1,8 @@
 class Adventure < ApplicationRecord
   has_many :reviews, dependent: :destroy
 
+  has_one_attached :photo
+
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?
   has_many :reviews

--- a/app/views/adventures/_form.html.erb
+++ b/app/views/adventures/_form.html.erb
@@ -9,6 +9,10 @@
     </div>
 
     <div class="form-inputs">
+      <%= f.input :photo, as: :file, hint: "This will be the main adventure picture so pick a good one!", label: "Upload one AMAZING picture of this adventure." %>
+    </div>
+
+    <div class="form-inputs">
       <%= f.input :category, collection: ['hiking trail', 'biking path'] %>
     </div>
 

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -25,7 +25,7 @@
   </div>
 
   <div class="form-inputs">
-    <%= f.input :photos, as: :file, input_html: { multiple: true } %>
+    <%= f.input :photos, as: :file, label: "You can attach a few AMAZING photos to your review.", input_html: { multiple: true } %>
   </div>
 
   <div class="form-actions btn btn-primary mt-4">


### PR DESCRIPTION
fixed bug where allowed form parameters were inconsistent with form fields

Review and adventure photo uploads from forms either added or fixed.

Do we want to limit the number of photos someone can add to a review to prevent 'photo bombing'?