### PR TITLE
navbar welcome moved to right with user email

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,21 +1,20 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
-  <%= link_to "/", class: "navbar-brand" do %>
-    <%= image_tag "logo_smcompass1.png", class: "avatar"%>
-    <% end %>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-
-  <div>
-    <h3><% if current_user.nil? %>
-          <%= "" %>
-        <% elsif current_user.admin? %>
-          <%= "God Mode" %>
-        <% else %>
-          <%= "Welcome!" %>
-        <% end %>
-
-     </h3>
+  <div class="navbar-nav">
+    <%= link_to "/", class: "navbar-brand" do %>
+      <%= image_tag "logo_smcompass1.png", class: "avatar"%>
+      <% end %>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <h3 class="mb-0 p-1">
+      <% if current_user.nil? %>
+        <%= "" %>
+      <% elsif current_user.admin? %>
+         <%= "God Mode (Admin)" %>
+      <% else %>
+         <%= "Welcome, #{current_user.email}!" %>
+      <% end %>
+    </h3>
   </div>
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">


### PR DESCRIPTION
moved 'Welcome'  and 'God Mode (Admin)' to left with logo.

Added user email for now for a more 'personal' touch since we don't have first names or usernames. Can remove if too weird/ugly.

<img width="1257" alt="Screen Shot 2020-05-06 at 7 35 24 PM" src="https://user-images.githubusercontent.com/52547142/81209467-de135580-8fd0-11ea-9047-1fee345812ce.png">
<img width="1267" alt="Screen Shot 2020-05-06 at 7 35 57 PM" src="https://user-images.githubusercontent.com/52547142/81209475-e10e4600-8fd0-11ea-8760-d469ef49f975.png">

