### PR TITLE
authors and admins can edit and destroy reviews now

### DIFF
--- a/app/policies/review_policy.rb
+++ b/app/policies/review_policy.rb
@@ -11,10 +11,10 @@ class ReviewPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user.admin?
+    user.admin? || record.user_id == user.id
   end
 
   def edit?
-    user.admin?
+    user.admin? || record.user_id == user.id
   end
 end

--- a/app/views/adventures/show.html.erb
+++ b/app/views/adventures/show.html.erb
@@ -86,13 +86,13 @@
             <p><%= "#{review.content[0..125]}..." %><%= render 'review_modal', review: review, index: index %></p>
 
               <% unless current_user.nil? %>
-                <% if policy(Review).edit? %>
+                <% if policy(review).edit? %>
                   <%= link_to edit_review_path(review),
                       method: :get do %>
                     <i style="font-size: 9pt" class=" fas fa-pencil-alt"></i>
                   <% end %>
                 <% end %>
-                <% if policy(Review).destroy? %>
+                <% if policy(review).destroy? %>
                     |
                   <%= link_to review_path(review),
                       method: :delete,


### PR DESCRIPTION
Since it was figured out how to do this on adventures, I could do the same with reviews now.