### PR TITLE
Fix review update pundit

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -27,9 +27,9 @@ class ReviewsController < ApplicationController
   end
 
   def update
-
+    authorize @review
     if @review.update(review_params)
-      redirect_to adventure_path(@review.adventure), notice: 'Your review was successfully updated.'
+      redirect_to my_adventures_path, notice: 'Your review was successfully updated.'
     else
       render :edit
     end

--- a/app/policies/review_policy.rb
+++ b/app/policies/review_policy.rb
@@ -14,7 +14,7 @@ class ReviewPolicy < ApplicationPolicy
     user.admin? || record.user_id == user.id
   end
 
-  def edit?
+  def update?
     user.admin? || record.user_id == user.id
   end
 end

--- a/app/views/adventures/show.html.erb
+++ b/app/views/adventures/show.html.erb
@@ -93,7 +93,7 @@
               <% end %>
             <p><%= review.created_at.strftime("%m/%d/%Y") %> | <%= "#{review.content[0..125]}..." %><%= render 'review_modal', review: review, index: index %></p>
 
-              <% unless current_user.nil? %>
+              <% if current_user.admin? %>
                 <% if policy(review).edit? %>
                   <%= link_to edit_review_path(review),
                       method: :get do %>


### PR DESCRIPTION
fixed pundit update policies for reviews. 

Also removed icons for 'normal' users on adventures show page since it's easier to edit their reviews on the my_adventures page. Only admins can see the icons on the show page.

