### PR TITLE
fixed review path for deleting when on my adventure

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -39,7 +39,7 @@ class ReviewsController < ApplicationController
   def destroy
     authorize @review
     @review.destroy
-    redirect_to adventure_path(@review.adventure), notice: "Your review was deleted"
+    redirect_to my_adventures_path, notice: "Your review was deleted"
   end
 
   private


### PR DESCRIPTION
fixed destroy path for reviews to redirect to my_adventure index page

However, as admin, it also redirects to the admin my_adventure index if deleted from the adventure show page. A little stupid, but not sure how to fix this.